### PR TITLE
#3996 joyride race condition fix

### DIFF
--- a/insQ.js
+++ b/insQ.js
@@ -56,11 +56,11 @@ var insertionQ = (function () {
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
         }
-
+        
         if(isTimeoutRequired) {
+            //event support is not consistent with DOM prefixes
             var bindAnimationLater = setTimeout(function () {
                 registerEventListeners();
-                //event support is not consistent with DOM prefixes
             }, options.timeout); //starts listening later to skip elements found on startup. this might need tweaking
         }
         else {

--- a/insQ.js
+++ b/insQ.js
@@ -13,6 +13,8 @@ var insertionQ = (function () {
             timeout: 20
         };
     
+    // determine if timeout is required in order register event listener immediately
+    // after animation is attached
     const isTimeoutRequired = (options.timeout > 0);
 
     if (elm.style.animationName) {

--- a/insQ.js
+++ b/insQ.js
@@ -57,7 +57,7 @@ var insertionQ = (function () {
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
         }
-        
+
         if(timeoutRequired) {
             var bindAnimationLater = setTimeout(function () {
                 registerEventListeners();
@@ -81,9 +81,6 @@ var insertionQ = (function () {
             }
         };
     }
-
-    function()
-
 
     function tag(el) {
         el.QinsQ = true; //bug in V8 causes memory leaks when weird characters are used as field names. I don't want to risk leaking DOM trees so the key is not '-+-' anymore

--- a/insQ.js
+++ b/insQ.js
@@ -12,7 +12,10 @@ var insertionQ = (function () {
             strictlyNew: true,
             timeout: 20
         };
-
+    
+    if( options.timeout > 0 ) {
+        const timeoutRequired = true;
+    }
     if (elm.style.animationName) {
         isAnimationSupported = true;
     }
@@ -49,23 +52,25 @@ var insertionQ = (function () {
 
         document.head.appendChild(styleAnimation);
 
-        if(options.timeout > 0) {
-            var bindAnimationLater = setTimeout(function () {
-                document.addEventListener('animationstart', eventHandler, false);
-                document.addEventListener('MSAnimationStart', eventHandler, false);
-                document.addEventListener('webkitAnimationStart', eventHandler, false);
-                //event support is not consistent with DOM prefixes
-            }, options.timeout); //starts listening later to skip elements found on startup. this might need tweaking
-        }
-        else {
+        const registerEventListeners = () => {
             document.addEventListener('animationstart', eventHandler, false);
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
         }
+        
+        if(timeoutRequired) {
+            var bindAnimationLater = setTimeout(function () {
+                registerEventListeners();
+                //event support is not consistent with DOM prefixes
+            }, options.timeout); //starts listening later to skip elements found on startup. this might need tweaking
+        }
+        else {
+            registerEventListeners();
+        }
 
         return {
             destroy: function () {
-                options.timeout > 0 ? clearTimeout(bindAnimationLater) : '';
+                timeoutRequired ? clearTimeout(bindAnimationLater) : '';
                 if (styleAnimation) {
                     document.head.removeChild(styleAnimation);
                     styleAnimation = null;
@@ -76,6 +81,8 @@ var insertionQ = (function () {
             }
         };
     }
+
+    function()
 
 
     function tag(el) {

--- a/insQ.js
+++ b/insQ.js
@@ -49,16 +49,23 @@ var insertionQ = (function () {
 
         document.head.appendChild(styleAnimation);
 
-        var bindAnimationLater = setTimeout(function () {
+        if(options.timeout > 0) {
+            var bindAnimationLater = setTimeout(function () {
+                document.addEventListener('animationstart', eventHandler, false);
+                document.addEventListener('MSAnimationStart', eventHandler, false);
+                document.addEventListener('webkitAnimationStart', eventHandler, false);
+                //event support is not consistent with DOM prefixes
+            }, options.timeout); //starts listening later to skip elements found on startup. this might need tweaking
+        }
+        else {
             document.addEventListener('animationstart', eventHandler, false);
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
-            //event support is not consistent with DOM prefixes
-        }, options.timeout); //starts listening later to skip elements found on startup. this might need tweaking
+        }
 
         return {
             destroy: function () {
-                clearTimeout(bindAnimationLater);
+                options.timeout > 0 ? clearTimeout(bindAnimationLater) : '';
                 if (styleAnimation) {
                     document.head.removeChild(styleAnimation);
                     styleAnimation = null;

--- a/insQ.js
+++ b/insQ.js
@@ -53,7 +53,7 @@ var insertionQ = (function () {
 
         document.head.appendChild(styleAnimation);
 
-        const registerEventListeners = () => {
+        const registerEventListeners = function() {
             document.addEventListener('animationstart', eventHandler, false);
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
@@ -61,9 +61,10 @@ var insertionQ = (function () {
         
         if(isTimeoutRequired) {
             //event support is not consistent with DOM prefixes
+            //starts listening later to skip elements found on startup. this might need tweaking
             var bindAnimationLater = setTimeout(function () {
                 registerEventListeners();
-            }, options.timeout); //starts listening later to skip elements found on startup. this might need tweaking
+            }, options.timeout);
         }
         else {
             registerEventListeners();

--- a/insQ.js
+++ b/insQ.js
@@ -13,9 +13,8 @@ var insertionQ = (function () {
             timeout: 20
         };
     
-    if( options.timeout > 0 ) {
-        const timeoutRequired = true;
-    }
+    const isTimeoutRequired = (options.timeout > 0);
+
     if (elm.style.animationName) {
         isAnimationSupported = true;
     }
@@ -58,7 +57,7 @@ var insertionQ = (function () {
             document.addEventListener('webkitAnimationStart', eventHandler, false);
         }
 
-        if(timeoutRequired) {
+        if(isTimeoutRequired) {
             var bindAnimationLater = setTimeout(function () {
                 registerEventListeners();
                 //event support is not consistent with DOM prefixes
@@ -70,7 +69,7 @@ var insertionQ = (function () {
 
         return {
             destroy: function () {
-                timeoutRequired ? clearTimeout(bindAnimationLater) : '';
+                isTimeoutRequired && clearTimeout(bindAnimationLater);
                 if (styleAnimation) {
                     document.head.removeChild(styleAnimation);
                     styleAnimation = null;


### PR DESCRIPTION
fixes #3996

joyride will no longer stall because we register the event listener right after the animation is attached. The original issue is with the setTimeout, even if we configure the timeout to 0, if the user clicks the next button at the right time, the engine is busy right after the animation is attached but before the event listener is registered, so then our callback to will not move onto the next step in the joyride because the event listener missed when the animation was attached. By removing the setTimeout, the event listener is immediately registered.