### PR TITLE
#3996 fixes double click

### DIFF
--- a/insQ.js
+++ b/insQ.js
@@ -10,12 +10,8 @@ var insertionQ = (function () {
         elm = document.createElement('div'),
         options = {
             strictlyNew: true,
-            timeout: 0
+            timeout: 20
         };
-    
-    // determine if timeout is required in order register event listener immediately
-    // after animation is attached
-    const isTimeoutRequired = (options.timeout > 0);
 
     if (elm.style.animationName) {
         isAnimationSupported = true;
@@ -58,7 +54,12 @@ var insertionQ = (function () {
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
         }
-        
+
+        // determine if timeout is required in order register event listener immediately
+        // after animation is attached
+        const isTimeoutRequired = function() {
+           return options.timeout > 0; 
+        }
         if(isTimeoutRequired) {
             //event support is not consistent with DOM prefixes
             //starts listening later to skip elements found on startup. this might need tweaking

--- a/insQ.js
+++ b/insQ.js
@@ -49,7 +49,7 @@ var insertionQ = (function () {
 
         document.head.appendChild(styleAnimation);
 
-        const registerEventListeners = function() {
+        var registerEventListeners = function() {
             document.addEventListener('animationstart', eventHandler, false);
             document.addEventListener('MSAnimationStart', eventHandler, false);
             document.addEventListener('webkitAnimationStart', eventHandler, false);
@@ -57,23 +57,23 @@ var insertionQ = (function () {
 
         // determine if timeout is required in order register event listener immediately
         // after animation is attached
-        const isTimeoutRequired = function() {
+        var isTimeoutRequired = function() {
            return options.timeout > 0; 
         }
+
         if(isTimeoutRequired()) {
             //event support is not consistent with DOM prefixes
             //starts listening later to skip elements found on startup. this might need tweaking
             var bindAnimationLater = setTimeout(function () {
                 registerEventListeners();
             }, options.timeout);
-        }
-        else {
+        } else {
             registerEventListeners();
         }
 
         return {
             destroy: function () {
-                isTimeoutRequired && clearTimeout(bindAnimationLater);
+                isTimeoutRequired() && clearTimeout(bindAnimationLater);
                 if (styleAnimation) {
                     document.head.removeChild(styleAnimation);
                     styleAnimation = null;

--- a/insQ.js
+++ b/insQ.js
@@ -46,9 +46,7 @@ var insertionQ = (function () {
             "\n" + selector + ' { animation-duration: 0.001s; animation-name: ' + animationName + '; ' +
             keyframeprefix + 'animation-duration: 0.001s; ' + keyframeprefix + 'animation-name: ' + animationName + '; ' +
             ' } ';
-
         document.head.appendChild(styleAnimation);
-
         var registerEventListeners = function() {
             document.addEventListener('animationstart', eventHandler, false);
             document.addEventListener('MSAnimationStart', eventHandler, false);

--- a/insQ.js
+++ b/insQ.js
@@ -10,7 +10,7 @@ var insertionQ = (function () {
         elm = document.createElement('div'),
         options = {
             strictlyNew: true,
-            timeout: 20
+            timeout: 0
         };
     
     // determine if timeout is required in order register event listener immediately

--- a/insQ.js
+++ b/insQ.js
@@ -60,7 +60,7 @@ var insertionQ = (function () {
         const isTimeoutRequired = function() {
            return options.timeout > 0; 
         }
-        if(isTimeoutRequired) {
+        if(isTimeoutRequired()) {
             //event support is not consistent with DOM prefixes
             //starts listening later to skip elements found on startup. this might need tweaking
             var bindAnimationLater = setTimeout(function () {


### PR DESCRIPTION
There was an issue where double-clicking would cause the joyride to stall or exit unexpectedly. It was because the default timeout was still set to 20. By setting it to 0, the event listener will now immediately be registered after the animation plays. The user can single/double click and the joyride will run smoothly